### PR TITLE
wip: page link graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 venv
+
+# PyCharm
+__pycache__

--- a/new_pagelinks/main.py
+++ b/new_pagelinks/main.py
@@ -1,17 +1,94 @@
 from wiki_page_revision_set import WikiPageRevisionSet
 
-import requests
+import grequests
+import re
+
+START_DATE = "2021-01-01T00:00:01"
+END_DATE = "2021-06-30T23:59:59"
+WIKIPEDIA_API_URL = "https://en.wikipedia.org/w/api.php"
+
+def create_urls(topic):
+    return  f"https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvlimit=max&titles={topic}&rvprop=timestamp|ids|content&rvstart=2021-06-30T23:59:59&rvend=2021-01-01T00:00:01"
+
+def process(response):
+    try:
+        revisions = parse_revisions(response)
+        return revisions
+    except DeadLinkException:
+        return None
+
+def parse_revisions(response):
+    topic_id = self.get_topic_id(response)
+    if topic_id == "-1":
+        raise DeadLinkException
+
+    revisions = []
+    page = get_page(response)
+    try:
+        page_revisions = page.json()["query"]["pages"][topic_id]["revisions"]
+    except KeyError:
+        return # The link is capitalized the wrong way in the API
+        
+    for revision in page_revisions:
+        try:
+            links = {}
+            link_element_regex = r"\[\[([a-zA-Z0-9 ]*)[\|\]]"
+
+            matches = re.findall(link_element_regex, content=revision["*"])
+        except KeyError:
+            continue # Content is hidden https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvlimit=1&titles=Beijing&rvslots=*&rvprop=content&rvstartid=1014076205
+    return revisions
+
+def get_topic_id(self, response):
+    """
+    Get the topic ID of the current topic.
+    There is only a single topic ID for each request unless several topics are requested.
+    """
+    pages = response.json()["query"]["pages"]
+    return list(pages.keys())[0]
+
+def get_page(self, response):
+    if "continue" in response.json():
+       rvcontinue = response.json()["continue"]["rvcontinue"]
+       return f"https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvlimit=max&titles={topic}&rvprop=timestamp|ids|content&rvstart=2021-06-30T23:59:59&rvend=2021-01-01T00:00:01&rvcontinue="
+    pass
 
 def __main__():
-    session = requests.Session()
+    topic_queue = ["Norway", "Sweden", "Denmark", "Belgium", "Finland", "Iceland", "Bulgaria", "Cyprus", "Germany", "France"]
+    pagination_queue = []
 
-    start_page = WikiPageRevisionSet("Erna Solberg", 1, request_session=session)
-    topics_seen = [start_page.topic]
+    while topic_queue:
+        next_topics, topic_queue = (topic_queue[:10], topic_queue[10:])
+        next_urls = generate_urls(next_topics)
+        responses = send_batch_requests(next_urls)
+
+        add_new_content(topic_queue, responses)
+        next_pages = get_next_pages(responses)
+        while next_pages:
+            responses = send_batch_requests(next_pages)
+            add_new_content(topic_queue, responses)
+            next_pages = get_next_pages(response)
+
+    # Må si hva hver post peker på. Kan lage en dictionary topic->revisionset
+
+
+
 
     topics = {}
     for revision in start_page.revisions:
         topics = {**topics, **revision.links}
     
+    urls = [create_urls(topic) for topic in topics.keys()]
+
+    responses = grequests.map(grequests.get(url) for url in urls)
+    print(responses[0].content)
+
+    while urls:
+        urls = [process(response) for response in responses]
+        responses = grequests.map(grequests.get(url) for url in urls)
+
+
+    """
     for topic in topics.keys():
         if topic not in topics_seen:
             print(topic)
@@ -20,15 +97,7 @@ def __main__():
 
 
     print(len(topics_seen))
-
-
-    """    
-    pages = [start_page]
-    pages_seen = []
-
-    start_page.get_revisions()
     """
-
 
 if __name__ == "__main__":
     __main__()

--- a/new_pagelinks/main.py
+++ b/new_pagelinks/main.py
@@ -1,0 +1,34 @@
+from wiki_page_revision_set import WikiPageRevisionSet
+
+import requests
+
+def __main__():
+    session = requests.Session()
+
+    start_page = WikiPageRevisionSet("Erna Solberg", 1, request_session=session)
+    topics_seen = [start_page.topic]
+
+    topics = {}
+    for revision in start_page.revisions:
+        topics = {**topics, **revision.links}
+    
+    for topic in topics.keys():
+        if topic not in topics_seen:
+            print(topic)
+            page_revision_set = WikiPageRevisionSet(topic, 2, request_session=session)
+            topics_seen.append(page_revision_set.topic)
+
+
+    print(len(topics_seen))
+
+
+    """    
+    pages = [start_page]
+    pages_seen = []
+
+    start_page.get_revisions()
+    """
+
+
+if __name__ == "__main__":
+    __main__()

--- a/new_pagelinks/revision.py
+++ b/new_pagelinks/revision.py
@@ -1,0 +1,25 @@
+import re
+
+
+class Revision:
+    def __init__(self, revision_id, timestamp, content, topic):
+        self.revision_id = revision_id
+        self.timestamp = timestamp
+        self.topic = topic
+        self.links = {}
+        self.generate_links(content)
+
+    def __str__(self):
+        return f"{self.revision_id} for {self.topic} at {self.timestamp} with links {str(self.links)}"
+
+    def generate_links(self, content):
+        links = {}
+        link_element_regex = r"\[\[([a-zA-Z0-9 ]*)[\|\]]"
+
+        matches = re.findall(link_element_regex, content)
+
+        for link in matches:
+            self.links[link] = True
+    
+
+

--- a/new_pagelinks/utils/exceptions/dead_link_exception.py
+++ b/new_pagelinks/utils/exceptions/dead_link_exception.py
@@ -1,0 +1,3 @@
+class DeadLinkException(Exception):
+    """ Raised when a dead (red) link is encountered. """
+    pass

--- a/new_pagelinks/wiki_page_revision_set.py
+++ b/new_pagelinks/wiki_page_revision_set.py
@@ -1,0 +1,118 @@
+import requests
+import re
+
+from revision import Revision
+from utils.exceptions.dead_link_exception import DeadLinkException
+
+
+START_DATE = "2021-01-01T00:00:01"
+END_DATE = "2021-06-30T23:59:59"
+WIKIPEDIA_API_URL = "https://en.wikipedia.org/w/api.php"
+
+
+class WikiPageRevisionSet:
+    """ Class containing all internal Wikipedia links for a single Wikipedia site. """
+
+    def __init__(self, topic, depth, request_session=None):
+        """ Initialize by translating topic to be on a WikiAPI accepted format. """
+        self.session = request_session if request_session else requests.Session()
+        self.topic = topic.replace(" ", "_")
+        self.revisions = self.get_revisions()
+        self.depth = depth
+
+    def _get_default_params(self):
+        return {
+            "action": "query",
+            "format": "json",
+            "prop": "revisions",
+            "rvlimit": "max",
+            "titles": self.topic,
+            "rvprop": "timestamp|ids|content",
+            "rvstart": END_DATE,
+            "rvend": START_DATE
+        }
+
+    def get_revisions(self):
+        """
+        Get revision data for a single topic.
+        NOTE: The revision timelime is backwards, hence rvstart is the END_DATE.
+        """
+        params = self._get_default_params()
+        
+        response = self.session.get(url=WIKIPEDIA_API_URL, params=params)
+        try:
+            revisions = self.parse_revisions(response)
+            return revisions
+        except DeadLinkException:
+            return None
+    
+    def parse_revisions(self, response):
+        """
+        Create Revision objects out of the response
+        """
+        topic_id = self.get_topic_id(response)
+        if topic_id == "-1":
+            raise DeadLinkException
+
+        revisions = []
+        for page in self.get_pages(response):
+            try:
+                page_revisions = page.json()["query"]["pages"][topic_id]["revisions"]
+            except KeyError:
+                continue # The link is capitalized the wrong way in the API
+            
+            for revision in page_revisions:
+
+                try:
+                    revisions.append(
+                        Revision(
+                            revision_id=revision["revid"],
+                            timestamp=revision["timestamp"], 
+                            content=revision["*"],
+                            topic=self.topic
+                        )
+                )
+                except KeyError:
+                    continue # Content is hidden https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvlimit=1&titles=Beijing&rvslots=*&rvprop=content&rvstartid=1014076205
+        return revisions
+        
+
+    def get_topic_id(self, response):
+        """
+        Get the topic ID of the current topic.
+        There is only a single topic ID for each request unless several topics are requested.
+        """
+        pages = response.json()["query"]["pages"]
+        return list(pages.keys())[0]
+
+
+    def get_pages(self, response):
+        pages = [response]
+        params = self._get_default_params()
+        while "continue" in response.json():
+            params["rvcontinue"] = response.json()["continue"]["rvcontinue"]
+            response = self.session.get(url=WIKIPEDIA_API_URL, params=params)
+            pages.append(response)
+
+        return pages
+
+
+    def propagate(self):
+        """
+        Get links and send new requests for all links encountered.
+
+        TODO: Batch requests in order to bump up depth.
+        See https://www.mediawiki.org/wiki/API:Etiquette for more information.
+        """
+
+        if self.depth >= 3:
+            return []
+
+        self.get_links_from_wiki()
+
+        next_pages = []
+        for link in self.links.keys():
+            link_revision = WikiPagelinkSet(link, self.depth + 1, self.t)
+            next_pages.append(link_revision)
+
+        return next_pages

--- a/pagelinks/main.py
+++ b/pagelinks/main.py
@@ -1,9 +1,9 @@
-from revision import WikiPagelinkSet
-from utils.timer import timeit
+from wiki_pagelink_set import WikiPagelinkSet
+from utils.timer import Timer
 
-@timeit
-def __main__():
-    start_page = WikiPagelinkSet("Erna Solberg", 1)
+
+def __main__(t):
+    start_page = WikiPagelinkSet("Erna Solberg", 1, t)
     pages = [start_page]
     pages_seen = []
 
@@ -13,7 +13,9 @@ def __main__():
 
         new_pages = [page for page in next_page.propagate() if page.topic not in pages_seen]
         pages.extend(new_pages)
-    
+
 
 if __name__ == "__main__":
-    __main__()
+    t = Timer()
+    t.timeit(__main__)(t)
+    print(t.funcs)

--- a/pagelinks/main.py
+++ b/pagelinks/main.py
@@ -1,0 +1,19 @@
+from revision import WikiPagelinkSet
+from utils.timer import timeit
+
+@timeit
+def __main__():
+    start_page = WikiPagelinkSet("Erna Solberg", 1)
+    pages = [start_page]
+    pages_seen = []
+
+    while pages:
+        next_page = pages.pop()
+        pages_seen.append(next_page.topic)
+
+        new_pages = [page for page in next_page.propagate() if page.topic not in pages_seen]
+        pages.extend(new_pages)
+    
+
+if __name__ == "__main__":
+    __main__()

--- a/pagelinks/utils/timer.py
+++ b/pagelinks/utils/timer.py
@@ -1,0 +1,16 @@
+import time
+
+
+def timeit(f):
+    """Decorator to time a function."""
+    def timed(*args, **kw):
+
+        ts = time.time()
+        result = f(*args, **kw)
+        te = time.time()
+
+        print('func:%r args:[%r, %r] took: %2.4f sec' % \
+          (f.__name__, args, kw, te-ts))
+        return result
+
+    return timed

--- a/pagelinks/utils/timer.py
+++ b/pagelinks/utils/timer.py
@@ -1,16 +1,23 @@
 import time
 
 
-def timeit(f):
-    """Decorator to time a function."""
-    def timed(*args, **kw):
+class Timer:
+    def __init__(self):
+        self.funcs = {}
 
-        ts = time.time()
-        result = f(*args, **kw)
-        te = time.time()
+    def timeit(self, f):
+        """Decorator to time a function."""
+        def timed(*args, **kw):
 
-        print('func:%r args:[%r, %r] took: %2.4f sec' % \
-          (f.__name__, args, kw, te-ts))
-        return result
+            ts = time.time()
+            result = f(*args, **kw)
+            te = time.time()
 
-    return timed
+            fname = f.__name__
+            self.funcs[fname] = self.funcs.setdefault(fname, 0) + te-ts
+
+            print('func:%r args:[%r, %r] took: %2.4f sec' %
+                  (f.__name__, args, kw, te-ts))
+            return result
+
+        return timed

--- a/pagelinks/wiki_pagelink_set.py
+++ b/pagelinks/wiki_pagelink_set.py
@@ -1,0 +1,55 @@
+import requests
+import re
+
+class WikiPagelinkSet:
+    """ Class containing all internal Wikipedia links for a single Wikipedia site. """
+
+    def __init__(self, topic, depth):
+        """ Initialize by translating topic to be on a WikiAPI accepted format. """
+        self.topic = topic.replace(" ", "_")
+        self.links = {}
+        self.depth = depth
+
+    def add_link(self, link):
+        try:
+            self.links[link] += 1
+        except KeyError:
+            self.links[link] = 0
+    
+    def get_links_from_wiki(self):
+        """ Send request to Wikipedia API, parse and get all internal wikipedia links. """
+        url = f"""https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvlimit=20&titles={self.topic}&rvlimit=max&rvprop=timestamp|content"""
+
+        response = requests.get(url)
+        pages = response.json()["query"]["pages"]
+        page_id = list(pages.keys())[0]
+
+        try:
+            revisions = pages[page_id]["revisions"]
+        except KeyError:
+            return
+
+        link_element_regex = r"\[\[([a-zA-Z0-9 ]*)[\|\]]"
+        matches = re.findall(link_element_regex, revisions[0]["*"])
+        for match in matches:
+            self.add_link(match)
+
+    def propagate(self):
+        """
+        Get links and send new requests for all links encountered.
+
+        TODO: Batch requests in order to bump up depth.
+        See https://www.mediawiki.org/wiki/API:Etiquette for more information.
+        """
+
+        if self.depth >= 3:
+            return []
+
+        self.get_links_from_wiki()
+
+        next_pages = []
+        for link in self.links.keys():
+            link_revision = WikiPagelinkSet(link, self.depth + 1)
+            next_pages.append(link_revision)
+
+        return next_pages

--- a/pagelinks/wiki_pagelink_set.py
+++ b/pagelinks/wiki_pagelink_set.py
@@ -4,7 +4,7 @@ import re
 class WikiPagelinkSet:
     """ Class containing all internal Wikipedia links for a single Wikipedia site. """
 
-    def __init__(self, topic, depth,t):
+    def __init__(self, topic, depth, t):
         """ Initialize by translating topic to be on a WikiAPI accepted format. """
         self.topic = topic.replace(" ", "_")
         self.links = {}


### PR DESCRIPTION
Add basic functionality for fetching internal links on Wikipedia pages. `main.py` currently fetches all outgoing links from the Erna Solberg wikipedia page with a depth of 3. This takes about 3 minutes on my crappy computer.

*How link extraction works*
Links are extracted by searching after links in the content field of each response. All links are inside a [[ ]] block or a [[ || block.

*Steps in order to finish the subproject*
[ ] We need to store all records somehow (either in a file or a db)
[ ] We need to rewrite to some more performant language, as it takes quite some time to fetch all links
[ ] We need to add some logic for storing revisions
[ ] We need to follow API Etiquette and send one large request rather than many small