### PR TITLE
feat: benchmark pageview interval query

### DIFF
--- a/benchmarking/benchmark.py
+++ b/benchmarking/benchmark.py
@@ -173,12 +173,18 @@ def exe_q6_neo(q_api):
     for interval in intervals:
         exe_too_slow(exe_q4_neo)
 
+cypher_pageviews_interval_start = Q4_datestart
+cypher_pageviews_interval_end = Q4_datestop
+
+@time_func_avg
+def exe_cypher_benchmark(q_api, limit):
+    data = exe_return(DB.NEO, q_api, cypher_pageviews_interval(cypher_pageviews_interval_start, cypher_pageviews_interval_end, limit))
 
 
 if __name__=="__main__":
     query_api = getInfluxClient().query_api()
     graph = getNeo4jDriver()
-
+    """
     print_header()
     exe_Q1_influx(query_api)
     exe_Q1_neo(graph)
@@ -194,4 +200,8 @@ if __name__=="__main__":
 
     exe_q6_influx(graph, query_api)
     exe_q6_neo(graph)
+    """
 
+
+    for limit in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]:
+        exe_cypher_benchmark(graph, limit)

--- a/benchmarking/benchmark.py
+++ b/benchmarking/benchmark.py
@@ -179,6 +179,7 @@ cypher_pageviews_interval_end = Q4_datestop
 @time_func_avg
 def exe_cypher_benchmark(q_api, limit):
     data = exe_return(DB.NEO, q_api, cypher_pageviews_interval(cypher_pageviews_interval_start, cypher_pageviews_interval_end, limit))
+    print(data.data())
 
 
 if __name__=="__main__":
@@ -203,5 +204,6 @@ if __name__=="__main__":
     """
 
 
-    for limit in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]:
+    #for limit in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]:
+    for limit in [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 11000]:
         exe_cypher_benchmark(graph, limit)

--- a/benchmarking/perf_time_functions.py
+++ b/benchmarking/perf_time_functions.py
@@ -10,7 +10,7 @@ def time_func_avg(func):
             func(*args, **kwargs)
             stop = perf_counter()
             sum += (stop-start)
-        print("avg," + func.__name__ + ","+ str(sum/repeats))
+        print(f"avg, {func.__name__}, {str(sum/repeats)}, {args}")
     return wrapFunc
 
 def time_func(func):

--- a/benchmarking/queries.py
+++ b/benchmarking/queries.py
@@ -30,7 +30,7 @@ def Q2_neo(from_time, to_time):
             "CALL { "
             "WITH page "
             "MATCH (page)-[:FIRST]->(p1:PageView)-[:NEXT*0..]->(p2:PageView)-[:NEXT*0..]->(p3:PageView) "
-            f"WHERE p2.timestamp >= datetime('{from_time}') AND p3.timestamp <= datetime('{to_time}') "
+            f"WHERE p2.timestamp >= '{from_time}' AND p3.timestamp <= '{to_time}' "
             "WITH p2, sum (p2.count) as total "
             "RETURN total "
             "LIMIT 1 "
@@ -88,3 +88,27 @@ Q6_influx = Q2_influx
 
 Q6_get_timestamps = "" + \
 "MATCH (p:Page{id:$page_id})-[r:LINKED_TO]->(Page) RETURN DISTINCT r.from_timestamp ORDER BY r.from_timestamp ASC;"
+
+
+
+
+
+def cypher_pageviews_interval(from_time, to_time, limit):
+    """
+    :param from_time: The start of the interval, in ISO date format.
+    :param to_time: The end of the interval, in ISO date format.
+    """
+    query = "" + \
+            ("MATCH (page:Page) "
+            "CALL { "
+            "WITH page "
+            "MATCH (page)-[:FIRST]->(p1:PageView)-[:NEXT*0..]->(p2:PageView)-[:NEXT*0..]->(p3:PageView) "
+            f"WHERE p2.timestamp >= '{from_time}' AND p3.timestamp <= '{to_time}' "
+            "WITH p2, sum (p2.count) as total "
+            "RETURN total "
+            "LIMIT 1 "
+            "} "
+
+            "RETURN page, total "
+            f"LIMIT {limit};")
+    return query


### PR DESCRIPTION
Henter pageviews mellom t_i og t_j og varierer `LIMIT`. Limit er alle toerpotenser fra 1 til 1024